### PR TITLE
Update portfolio cartoon imagery

### DIFF
--- a/about.html
+++ b/about.html
@@ -76,8 +76,8 @@
 
           <figure>
             <img
-              src="images/Cartoon/CartoonRelaxedSuit.png"
-              alt="Cartoon portrait of Robin Hoffpauir in a relaxed suit"
+              src="images/Cartoon/armscrossed-yellowtie.png"
+              alt="Cartoon portrait of Robin Hoffpauir with arms crossed wearing a yellow tie"
               loading="lazy"
             />
           </figure>

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
             <article class="media-card">
               <a href="about.html">
                 <figure>
-                  <img src="images/Cartoon/Cartoon3piece.png" alt="About Robin" />
+                  <img src="images/Cartoon/standing-stoic-yellowtie.png" alt="About Robin" />
                   <figcaption>About</figcaption>
                 </figure>
                 <div class="media-content">
@@ -180,7 +180,7 @@
             <article class="media-card">
               <a href="resume.html">
                 <figure>
-                  <img src="images/Cartoon/CartoonDesk.png" alt="Resume" />
+                  <img src="images/Cartoon/yellowtie-desk.png" alt="Resume" />
                   <figcaption>Résumé</figcaption>
                 </figure>
                 <div class="media-content">
@@ -193,7 +193,7 @@
             <article class="media-card">
               <a href="data-visualizations.html">
                 <figure>
-                  <img src="images/Cartoon/CartoonTabletSales.png" alt="Data visualizations" />
+                  <img src="images/Cartoon/presentation-whiteboard-yellowtie.png" alt="Data visualizations" />
                   <figcaption>Data &amp; Visuals</figcaption>
                 </figure>
                 <div class="media-content">
@@ -206,7 +206,7 @@
             <article class="media-card">
               <a href="thought-leadership.html">
                 <figure>
-                  <img src="images/Cartoon/CartoonBizCasualPointing.png" alt="Writing" />
+                  <img src="images/Cartoon/standing-reading-yellowtie.png" alt="Writing" />
                   <figcaption>Writing</figcaption>
                 </figure>
                 <div class="media-content">


### PR DESCRIPTION
## Summary
- swap portfolio card artwork to the latest yellow-tie cartoon set
- refresh the About page portrait to the new illustration style

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433247fb88832c91b2cf33695acac9)