### PR TITLE
Update portfolio cartoon imagery and featured wins layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -76,8 +76,8 @@
 
           <figure>
             <img
-              src="images/Cartoon/CartoonRelaxedSuit.png"
-              alt="Cartoon portrait of Robin Hoffpauir in a relaxed suit"
+              src="images/Cartoon/armscrossed-yellowtie.png"
+              alt="Cartoon portrait of Robin Hoffpauir with arms crossed wearing a yellow tie"
               loading="lazy"
             />
           </figure>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -392,24 +392,76 @@ nav ul {
   margin-bottom: calc(var(--spacing-unit) * 3);
 }
 
-.win-grid {
+.win-layout {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: calc(var(--spacing-unit) * 2);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: calc(var(--spacing-unit) * 3);
+  align-items: start;
 }
 
-.win-card {
+.win-summary {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   padding: calc(var(--spacing-unit) * 3);
   box-shadow: var(--shadow-elevation-1);
+}
+
+.win-subtitle {
+  margin: 0 0 calc(var(--spacing-unit) * 1.5);
+  font-size: 1.05rem;
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-on-surface);
+}
+
+.win-bullets {
+  list-style: disc;
+  padding-left: calc(var(--spacing-unit) * 3);
+  margin: 0;
   display: grid;
-  gap: calc(var(--spacing-unit) * 1);
+  gap: calc(var(--spacing-unit) * 1.25);
+  color: var(--color-on-surface-secondary);
+}
+
+.win-bullets strong {
+  color: var(--color-on-surface);
+}
+
+.win-table-wrapper {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-elevation-1);
+  overflow: hidden;
+}
+
+.win-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.win-table thead {
+  background-color: var(--color-surface-raised, #f7f7f7);
+}
+
+.win-table th,
+.win-table td {
+  padding: calc(var(--spacing-unit) * 2);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.win-table th {
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-on-surface);
+}
+
+.win-table tr:last-of-type td {
+  border-bottom: none;
 }
 
 .win-metric {
-  font-size: 1.5rem;
+  font-size: 1.15rem;
   font-weight: var(--font-weight-bold);
   color: var(--color-on-surface);
   margin: 0;
@@ -423,6 +475,7 @@ nav ul {
 
 .win-detail {
   margin: 0;
+  color: var(--color-on-surface-secondary);
 }
 
 /* Cards */

--- a/index.html
+++ b/index.html
@@ -131,27 +131,50 @@
           <p class="section-intro">Outcomes from GTM builds across usage-based and enterprise motions.</p>
         </div>
 
-        <div class="win-grid">
-          <article class="win-card">
-            <p class="win-metric">+28%</p>
-            <p class="win-label">Net Revenue Retention</p>
-            <p class="win-detail">Improved PLG-to-sales conversions and expansion rigor in platform accounts.</p>
-          </article>
-          <article class="win-card">
-            <p class="win-metric">32% faster</p>
-            <p class="win-label">Enterprise Cycle Time</p>
-            <p class="win-detail">Standardized deal desk, pricing guardrails, and partner attach plays.</p>
-          </article>
-          <article class="win-card">
-            <p class="win-metric">7-figure</p>
-            <p class="win-label">Channel Influence</p>
-            <p class="win-detail">Activated ecosystem programs to drive co-sell and pipeline quality.</p>
-          </article>
-          <article class="win-card">
-            <p class="win-metric">Board-ready</p>
-            <p class="win-label">Operating System</p>
-            <p class="win-detail">Unified dashboards aligning finance, product, and sales on forecast health.</p>
-          </article>
+        <div class="win-layout">
+          <div class="win-summary">
+            <h3 class="win-subtitle">What good looks like</h3>
+            <ul class="win-bullets">
+              <li><strong>Retention</strong>: Usage-led expansion discipline that lifts NRR.</li>
+              <li><strong>Velocity</strong>: Standardized deal desks that shorten enterprise cycles.</li>
+              <li><strong>Channel</strong>: Partner motions that add influence without margin drag.</li>
+              <li><strong>Visibility</strong>: Executive dashboards that align finance, product, and sales.</li>
+            </ul>
+          </div>
+
+          <div class="win-table-wrapper">
+            <table class="win-table" aria-label="Featured wins table">
+              <thead>
+                <tr>
+                  <th scope="col">Metric</th>
+                  <th scope="col">Focus</th>
+                  <th scope="col">Outcome</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td class="win-metric">+28%</td>
+                  <td class="win-label">Net Revenue Retention</td>
+                  <td class="win-detail">Improved PLG-to-sales conversions and expansion rigor in platform accounts.</td>
+                </tr>
+                <tr>
+                  <td class="win-metric">32% faster</td>
+                  <td class="win-label">Enterprise Cycle Time</td>
+                  <td class="win-detail">Standardized deal desk, pricing guardrails, and partner attach plays.</td>
+                </tr>
+                <tr>
+                  <td class="win-metric">7-figure</td>
+                  <td class="win-label">Channel Influence</td>
+                  <td class="win-detail">Activated ecosystem programs to drive co-sell and pipeline quality.</td>
+                </tr>
+                <tr>
+                  <td class="win-metric">Board-ready</td>
+                  <td class="win-label">Operating System</td>
+                  <td class="win-detail">Unified dashboards aligning finance, product, and sales on forecast health.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </section>
 
@@ -167,7 +190,7 @@
             <article class="media-card">
               <a href="about.html">
                 <figure>
-                  <img src="images/Cartoon/Cartoon3piece.png" alt="About Robin" />
+                  <img src="images/Cartoon/standing-stoic-yellowtie.png" alt="About Robin" />
                   <figcaption>About</figcaption>
                 </figure>
                 <div class="media-content">
@@ -180,7 +203,7 @@
             <article class="media-card">
               <a href="resume.html">
                 <figure>
-                  <img src="images/Cartoon/CartoonDesk.png" alt="Resume" />
+                  <img src="images/Cartoon/yellowtie-desk.png" alt="Resume" />
                   <figcaption>Résumé</figcaption>
                 </figure>
                 <div class="media-content">
@@ -193,7 +216,7 @@
             <article class="media-card">
               <a href="data-visualizations.html">
                 <figure>
-                  <img src="images/Cartoon/CartoonTabletSales.png" alt="Data visualizations" />
+                  <img src="images/Cartoon/presentation-whiteboard-yellowtie.png" alt="Data visualizations" />
                   <figcaption>Data &amp; Visuals</figcaption>
                 </figure>
                 <div class="media-content">
@@ -206,7 +229,7 @@
             <article class="media-card">
               <a href="thought-leadership.html">
                 <figure>
-                  <img src="images/Cartoon/CartoonBizCasualPointing.png" alt="Writing" />
+                  <img src="images/Cartoon/standing-reading-yellowtie.png" alt="Writing" />
                   <figcaption>Writing</figcaption>
                 </figure>
                 <div class="media-content">


### PR DESCRIPTION
## Summary
- swap portfolio card artwork to the latest yellow-tie cartoon set
- refresh the About page portrait to the new illustration style
- restyle the Featured Wins section with summary bullets and a structured table

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69433247fb88832c91b2cf33695acac9)