### PR TITLE
Increase media card image sizes on home page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -584,9 +584,8 @@ nav ul {
 }
 
 .media-card img {
-  height: 260px;
-  width: auto;
-  max-width: 100%;
+  height: clamp(280px, 32vw, 360px);
+  width: min(100%, 420px);
   object-fit: contain;
   border-radius: calc(var(--border-radius) * 1.1);
   background: transparent;
@@ -723,7 +722,8 @@ footer {
   }
 
   .media-card img {
-    height: auto;
+    height: clamp(240px, 60vw, 320px);
+    width: min(100%, 380px);
   }
 }
 /* --- About Page Custom Styles --- */


### PR DESCRIPTION
## Summary
- enlarge media card imagery on the Explore section to make thumbnails more prominent
- adjust responsive sizing limits so images scale up while staying within layout bounds

## Testing
- `npm exec --yes prettier@3.2.5 --check index.html assets/css/styles.css`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69434685e38c832c86ecba13555a41b7)