### PR TITLE
Add revenue growth visuals and update portfolio narrative

### DIFF
--- a/data-visualizations.html
+++ b/data-visualizations.html
@@ -177,65 +177,78 @@
         </section>
         <!-- === End Partnerships & GTM Analytics Section === -->
 
-        <!-- --- Baseball Data Analytics Section --- -->
-        <section id="sabermetrics">
-          <h2>Advanced Sabermetrics &amp; Statcast Analysis</h2>
+        <section id="revenue-leadership">
+          <h2>Revenue Growth &amp; Sales Leadership</h2>
           <p>
-            Beyond business metrics, I explore data through my lifelong
-            connection to baseball. Using Statcast data and Python-based
-            visualization tools, I analyze how launch angle, exit velocity, and
-            contact quality correlate with on-field outcomes — applying the same
-            principles of analytics, iteration, and optimization that drive my
-            professional work.
+            Driving growth has meant expanding into new geographies and
+            industries while balancing the portfolio across net-new, expansion,
+            and partner-influenced deals. The programs highlighted below capture
+            market expansion, healthier product mix, accelerated cycle times,
+            and the win-rate improvements that came from clearer qualification
+            and enablement.
           </p>
+
+          <ul>
+            <li>
+              Elevated annual recurring revenue by simultaneously growing top of
+              funnel and improving YoY conversion from pilot to scale.
+            </li>
+            <li>
+              Built a verticalized approach that concentrated coverage on the
+              industries generating the majority of bookings while seeding new
+              logo growth in emerging segments.
+            </li>
+            <li>
+              Reduced sales cycle duration and boosted win rates through tighter
+              deal qualification, buyer-aligned messaging, and co-selling with
+              technology partners.
+            </li>
+          </ul>
 
           <div class="photo-gallery">
             <figure>
               <img
-                src="images/hit_distance_using_launchspeed.png"
-                alt="Hit distance versus launch speed plot"
+                src="images/plots/Combo_Revenue_YoY.png"
+                alt="Line and bar chart showing annual recurring revenue growth alongside year-over-year percentage gains."
                 loading="lazy"
+                style="border-radius:12px; box-shadow:var(--shadow-elevation-2); max-width:100%; height:auto;"
               />
               <figcaption>
-                Hit Distance vs. Launch Speed — showing how exit velocity
-                directly impacts flight distance.
+                <strong>Annual Revenue &amp; YoY Growth:</strong> Illustrates
+                expanding ARR, highlighting how new market entries and improved
+                renewal discipline accelerated year-over-year performance.
               </figcaption>
             </figure>
 
             <figure>
               <img
-                src="images/est_ba_using_speedangle.png"
-                alt="Estimated batting average using launch speed and angle"
+                src="images/plots/partner_ecosystem_growth_chart.png"
+                alt="Pareto-style bar chart ranking revenue contribution by industry vertical with cumulative share overlay."
                 loading="lazy"
+                style="border-radius:12px; box-shadow:var(--shadow-elevation-2); max-width:100%; height:auto;"
               />
               <figcaption>
-                Estimated Batting Average by Launch Speed &amp; Angle —
-                visualizing optimized contact zones for hitters.
+                <strong>Pareto by Industry Vertical:</strong> Shows how focus on
+                top-performing sectors shaped the portfolio mix while creating
+                headroom to incubate adjacent verticals.
               </figcaption>
             </figure>
 
             <figure>
               <img
-                src="images/launch_speed_angle.png"
-                alt="Launch speed and angle density plot"
+                src="images/plots/Sales_Efficiency_Impact.png"
+                alt="Dashboard highlighting sales cycle reductions, pipeline velocity, and improved win rates from efficiency initiatives."
                 loading="lazy"
+                style="border-radius:12px; box-shadow:var(--shadow-elevation-2); max-width:100%; height:auto;"
               />
               <figcaption>
-                Launch Speed &amp; Angle Distribution — identifying
-                power/contact tradeoffs across player profiles.
+                <strong>Sales Efficiency Impact:</strong> Captures the cycle-time
+                reductions and conversion gains delivered through streamlined
+                qualification, playbooks, and partner-assisted co-selling.
               </figcaption>
             </figure>
           </div>
-
-          <p>
-            These models were built in Python using
-            <strong>Pandas</strong>, <strong>Matplotlib</strong>, and
-            <strong>Statcast datasets</strong>, emphasizing how small
-            adjustments in mechanics produce measurable differences in outcomes
-            — a principle that applies equally in sales, sports, and strategy.
-          </p>
         </section>
-        <!-- --- End Baseball Data Analytics Section --- -->
 
         <div class="hero-actions">
           <a class="btn" href="index.html">&larr; Back to Home</a>


### PR DESCRIPTION
## Summary
- replace the sabermetrics section with a revenue growth and sales leadership narrative that highlights market expansion and portfolio improvements
- embed new revenue, industry Pareto, and sales efficiency charts with captions and consistent gallery styling

## Testing
- npx --yes htmlhint data-visualizations.html

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944df1cb670832c81dd98735ee2d4ba)